### PR TITLE
add scripts for installing per user fuse online

### DIFF
--- a/rhmi/README.md
+++ b/rhmi/README.md
@@ -1,0 +1,37 @@
+## User Fuse Online Installation
+### Prerequisite
+- RHMI 2.x installed on the cluster
+- [oc cli](https://docs.openshift.com/container-platform/4.3/cli_reference/openshift_cli/getting-started-cli.html#installing-the-cli)
+
+### Usage
+
+**IMPORTANT**: Each fuse online installation uses 3Gi of persistent volume storage. Ensure that the cluster resource quota for `resources.storage` allows for the amount of storage required by fuse online installations that you're about to create.
+
+```
+DEV_USERNAME=evals NUM_USERS=40 ./user-fuse-installation.sh
+```
+
+Optional Parameters:
+  - **DEV_USERNAME**: The username format of a developer user. Default value is `evals`.
+  - **NUM_USERS**: The number of developer users to create additional fuse online installations for. Default value is `10`.
+  - **FUSE_NAMESPACE**: The managed shared fuse product namespace. Default value is `redhat-rhmi-fuse`.
+  - **FUSE_OPERATOR_NAMESPACE**: The managed shared fuse operator namespace. Default value is `redhat-rhmi-fuse-operator`.
+
+## User Fuse Online Uninstallation
+Once the user fuse online installations are no longer needed, they can be cleaned up by running the uninstallation script.
+
+```
+DEV_USERNAME=evals ./user-fuse-cleanup.sh
+```
+
+Optional Parameters:
+    - **DEV_USERNAME**: The username format of a developer user. Default value is `evals`.
+
+## Updating the Solution Explorer
+The solution explorer walkthroughs currently links to the managed shared fuse online console. In order to point to the per user fuse online console within the walkthroughs, the solution explorer deployment image needs to be updated to **quay.io/pb82/tutorial-web-app:summit**. 
+
+**IMPORTANT**: Before updating the deployment, ensure that the solution explorer operator is not running as this will reconcile the solution explorer deployment back to using its original image. 
+
+
+
+

--- a/rhmi/templates/fuse-operator-group.yaml
+++ b/rhmi/templates/fuse-operator-group.yaml
@@ -1,0 +1,17 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: user-fuse-operator-group
+objects:
+  - apiVersion: operators.coreos.com/v1
+    kind: OperatorGroup
+    metadata:
+      name: ${USER_FUSE_NAMESPACE}-og
+      namespace: ${USER_FUSE_NAMESPACE}
+    spec:
+      targetNamespaces:
+      - ${USER_FUSE_NAMESPACE}
+parameters:
+  - description: The user fuse namespace
+    name: USER_FUSE_NAMESPACE
+    required: true

--- a/rhmi/templates/fuse-subscription.yaml
+++ b/rhmi/templates/fuse-subscription.yaml
@@ -1,0 +1,25 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: user-fuse-subscription
+objects:
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: ${USERNAME}-syndesis
+      namespace: ${USER_FUSE_NAMESPACE}
+    spec:
+      channel: rhmi
+      config:
+        resources: {}
+      installPlanApproval: Manual
+      name: rhmi-syndesis
+      source: rhmi-registry-cs
+      sourceNamespace: ${USER_FUSE_NAMESPACE}
+parameters:
+  - description: The user's username
+    name: USERNAME
+    required: true
+  - description: The user fuse namespace
+    name: USER_FUSE_NAMESPACE
+    required: true

--- a/rhmi/user-fuse-cleanup.sh
+++ b/rhmi/user-fuse-cleanup.sh
@@ -1,0 +1,23 @@
+DEV_USERNAME="${DEV_USERNAME:-evals}"
+
+
+# Remove all syndesis custom resource
+for i in $(oc get syndesis --all-namespaces | grep $DEV_USERNAME | awk '{print $2}'); do
+    oc delete syndesis $i -n $i-fuse
+done
+
+# Remove subscriptions
+for i in $(oc get subscriptions --all-namespaces | grep $DEV_USERNAME | awk '{print $2}'); do
+    NAMESPACE=$(echo $i | sed 's/syndesis/fuse/g')
+    oc delete subscription $i -n $NAMESPACE
+done
+
+# Remove operator group
+for i in $(oc get operatorgroups --all-namespaces  | grep -v NAMESPACE | grep $DEV_USERNAME | awk '{print $1}'); do
+    oc delete operatorgroup $i-og -n $i
+done
+
+# Remove namespaces
+for i in $(oc get projects -l user-fuse-online=true | grep -v NAME | awk '{print $1}'); do
+    oc delete namespace $i
+done

--- a/rhmi/user-fuse-installation.sh
+++ b/rhmi/user-fuse-installation.sh
@@ -1,0 +1,78 @@
+NUM_USERS="${NUM_USERS:-10}"
+DEV_USERNAME="${DEV_USERNAME:-evals}"
+FUSE_NAMESPACE="${FUSE_NAMESPACE:-redhat-rhmi-fuse}"
+FUSE_OPERATOR_NAMESPACE="${FUSE_NAMESPACE:-redhat-rhmi-fuse-operator}"
+
+NUM_FORMAT=${#NUM_USERS}
+if [ $NUM_FORMAT -eq 1 ]; then
+  NUM_FORMAT=2
+fi
+USERNAME_TEMPLATE="${DEV_USERNAME}%0${NUM_FORMAT}d"
+
+create_fuse_resources() {
+  USERNAME=$(printf ${USERNAME_TEMPLATE} $1)
+  NAMESPACE="${USERNAME}-fuse"
+
+  # Create and switch to user fuse project
+  oc create namespace $NAMESPACE
+  oc label namespace $NAMESPACE integreatly=true user-fuse-online=true
+  
+  # Create fuse pull secret
+  oc get secret syndesis-pull-secret -n $FUSE_NAMESPACE -o yaml | sed '/namespace:/d' | oc create -n $NAMESPACE -f -
+
+  # Give user view permission to the namespace
+  oc create rolebinding $USERNAME-view --clusterrole="view" --user=$USERNAME -n $NAMESPACE
+
+  # Create catalog source
+  oc get configmap registry-cm-redhat-rhmi-fuse-operator -n $FUSE_OPERATOR_NAMESPACE -o yaml | sed "/namespace: $FUSE_OPERATOR_NAMESPACE/d" | oc create -n $NAMESPACE -f -
+  oc get catalogsource rhmi-registry-cs -n $FUSE_OPERATOR_NAMESPACE -o yaml | sed '/namespace:/d' | oc create -n $NAMESPACE -f -
+  sleep 20
+
+  until [[ $(oc get catalogsource rhmi-registry-cs -n $NAMESPACE -o jsonpath='{.status.connectionState.lastObservedState}' | awk -F\. '{print $1}') == "READY" ]]; do
+    echo "waiting for catalog source in $NAMESPACE namespace to be ready"
+    sleep 30
+  done
+
+  # Create operator group
+  oc process -p USER_FUSE_NAMESPACE=$NAMESPACE -f "${BASH_SOURCE%/*}/templates/fuse-operator-group.yaml" | oc create -f -
+
+  # Create subscription
+  oc process -p USERNAME=$USERNAME USER_FUSE_NAMESPACE=$NAMESPACE -f "${BASH_SOURCE%/*}/templates/fuse-subscription.yaml" | oc create -f -
+
+  # Create operator group
+  oc process -p USER_FUSE_NAMESPACE=$NAMESPACE -f "${BASH_SOURCE%/*}/templates/fuse-operator-group.yaml" | oc create -f -
+
+  # Create subscription
+  oc process -p USERNAME=$USERNAME USER_FUSE_NAMESPACE=$NAMESPACE -f "${BASH_SOURCE%/*}/templates/fuse-subscription.yaml" | oc create -f -
+  sleep 20
+
+  # Ensure install plan exists before proceeding
+  until [[ $(oc get installplans -n $NAMESPACE --ignore-not-found=true | grep -v NAME | wc -l) -eq 1 ]]; do
+    echo "waiting for installplan to become available in $NAMESPACE"
+    sleep 10
+  done
+
+  # Approve install plan
+  oc patch installplan $(oc get installplans -n $NAMESPACE | grep -v NAME | awk '{print $1}') -n $NAMESPACE --type='json' -p '[{"op": "replace", "path": "/spec/approved", "value": true}]'
+
+  # Create the Syndesis CR
+  oc get syndesis integreatly -n redhat-rhmi-fuse -o yaml | sed "/namespace: redhat-rhmi-fuse/d;/annotations/,/applicationUrl/d;s/name: integreatly/name: $USERNAME/g;/status:/,/version:/d" | oc create -n $NAMESPACE -f -
+}
+
+for ((i = 1; i <= NUM_USERS; i++)); do
+  sleep 10
+  create_fuse_resources $i &
+done
+
+wait
+
+# Check installations status
+# watch "oc get syndesis --all-namespaces | grep -v Installed | grep -v NAMESPACE"
+
+echo "Checking Fuse Online installation status"
+until [[ $(oc get syndesis --all-namespaces | grep -v Installed | grep -v NAMESPACE | wc -l) -eq 0 ]]; do
+  NUM_REMAINING_INSTALLATIONS=$(oc get syndesis --all-namespaces | grep -v Installed | grep -v NAMESPACE | wc -l)
+  echo "There are $NUM_REMAINING_INSTALLATIONS installations still in progress"
+  sleep 60
+done
+echo "Fuse Online installation has completed for $NUM_USERS users"


### PR DESCRIPTION
This script will create all resources required to install fuse online and is based on the process of how the rhmi operator installs [fuse](https://github.com/integr8ly/integreatly-operator/blob/master/pkg/products/fuse/reconciler.go).

This will create the following resources in order:
- Fuse CSV copied from the managed fuse CSV
- Syndesis pull secret copied from the secret in the managed fuse namespace
- Rolebinding to add namespace view permissions for the dev user.
- Fuse catalog source copied from the managed fuse catalog source
- Fuse operator group processed from a template
- Fuse subscription processed from a template
- Syndesis custom resource with spec copied from the managed fuse custom resource

Usage: 
```
NUM_USERS=40 /user-fuse-installation.sh
```

A cleanup script was also incuded in the change to cleanup any resources created by the installation script.

Usage: 
```
./user-fuse-cleanup.sh
```

Related JIRA: https://issues.redhat.com/browse/INTLY-6720
