### PR TITLE
add threescale tenants per user via ansible role

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -31,6 +31,15 @@ ansible-playbook playbooks/install.yml \
 -e lab_user_count=75
 ```
 
+If you are already targeting the OpenShift cluster with `oc`, you can run:
+
+```bash
+ansible-playbook playbooks/install.yml \
+-e oc_login_token=$(oc whoami -t) \
+-e oc_login_server=$(oc get infrastructure cluster -o jsonpath='{.status.apiServerURL}') \
+-e lab_user_count=75
+```
+
 Once this has completed you can login as `evals01` thru `evals75` using the
 password `$USERNAME-password` where `$USERNAME` is `evals01` or similar, e.g
 `evals01-password`.

--- a/ansible/playbooks/create-tenants.yml
+++ b/ansible/playbooks/create-tenants.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  gather_facts: yes
+  tasks:
+    - include_role:
+        name: threescale

--- a/ansible/playbooks/install.yml
+++ b/ansible/playbooks/install.yml
@@ -3,6 +3,7 @@
 # Users are now created during cluster provision
 # - import_playbook: ./create-users.yml
 - import_playbook: ./project-setup.yml
+- import_playbook: ./create-tenants.yml
 
 - hosts: localhost
   gather_facts: no

--- a/ansible/playbooks/uninstall.yml
+++ b/ansible/playbooks/uninstall.yml
@@ -6,3 +6,8 @@
         name: requirements
     - include_role:
         name: uninstall
+    - include_role:
+        name: threescale
+      vars:
+        action: uninstall
+

--- a/ansible/roles/project-setup/tasks/main.yml
+++ b/ansible/roles/project-setup/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Create backing project
   shell: oc new-project {{project_name}}
+  register: _action_create_project
+  failed_when: _action_create_project.rc != 0 and 'AlreadyExists' not in _action_create_project.stderr
 
 - name: Create AMQ Streams cluster
   shell: oc apply -f {{role_path}}/files/kafka.cluster.yml -n {{project_name}}

--- a/ansible/roles/threescale/defaults/main.yml
+++ b/ansible/roles/threescale/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+action: install
+namespace: redhat-rhmi-3scale
+
+seed_secret_name: system-seed
+
+tmp_dir: /tmp
+
+# default tenant details
+tenant_name: admin-tenant
+tenant_admin_user: admin
+tenant_admin_email: admin@example.com
+tenant_admin_password: Password1
+tenant_detail_secret_name: "{{ tenant_name }}"
+tenant_detail_secret_namespace: "{{ namespace }}"
+tenant_id_format: evals%02d-tenant
+
+# template references
+template_credential_secret: tenant-secret.json.j2
+template_tenant_resource: tenant.json.j2 

--- a/ansible/roles/threescale/tasks/create-tenant.yml
+++ b/ansible/roles/threescale/tasks/create-tenant.yml
@@ -1,0 +1,81 @@
+---
+
+# set internal util variables
+
+- set_fact:
+    _tenant_id: "{{ tenant_id_format | format(item|int) }}"
+    _tenant_count: "{{ item }}"
+    _tenant_admin_username: "{{ lab_users_name_format | format(item|int) }}"
+    _tenant_admin_password: "{{ lab_users_name_format | format(item|int) }}-password"
+    _tenant_admin_email: "{{ lab_users_name_format | format(item|int) }}@example.com"
+
+- debug: msg="creating tenant with id '{{ _tenant_id }}' and admin user {{ _tenant_admin_username }}"
+
+## tenants require a secret to specify the admin credentials
+## create the secret
+
+- debug: msg="creating credential secret for admin user {{ _tenant_admin_username }}"
+
+- set_fact:
+    _tenant_admin_secret_file: "{{ tmp_dir }}/tenant-{{ _tenant_count }}-secret.json"
+    _tenant_admin_secret_name: "{{ _tenant_id }}-admin-credentials"
+
+- name: process tenant {{ _tenant_id }} credentials secret template
+  template:
+    src: "{{ template_credential_secret }}"
+    dest: "{{ _tenant_admin_secret_file }}"
+  vars:
+    tenant_admin_secret: "{{ _tenant_admin_secret_name }}"
+    tenant_admin_password: "{{ _tenant_admin_password | b64encode }}"
+
+- name: create tenant {{ _tenant_id }} credentials secret
+  shell: oc create -f {{ _tenant_admin_secret_file }} -n {{ namespace }}
+  register: _action_create_secret
+  failed_when: _action_create_secret.rc != 0 and 'AlreadyExists' not in _action_create_secret.stderr
+
+# create the tenant custom resource and wait for it to reconcile
+# it is considered reconciled when it has a status block
+
+- debug: msg="creating tenant custom resource for tenant {{ _tenant_id }}"
+
+- set_fact:
+    _tenant_resource_file: "{{ tmp_dir }}/tenant-{{ _tenant_count }}-resource.json"
+    _tenant_detail_secret_name: "{{ _tenant_id }}-details"
+
+- name: process tenant {{ _tenant_id }} custom resource template
+  template:
+    src: "{{ template_tenant_resource }}"
+    dest: "{{ _tenant_resource_file }}"
+  vars:
+    tenant_name: "{{ _tenant_id }}"
+    tenant_admin_email: "{{ _tenant_admin_email }}"
+    tenant_admin_user: "{{ _tenant_admin_username }}"
+    tenant_admin_secret: "{{ _tenant_admin_secret_name }}"
+    tenant_detail_secret_name: "{{ _tenant_detail_secret_name }}"
+    tenant_detail_secret_namespace: "{{ namespace }}"
+
+- name: create tenant {{ _tenant_id }} custom resource
+  shell: oc create -f {{ _tenant_resource_file }} -n {{ namespace }}
+  register: _action_create_resource
+  failed_when: _action_create_resource.rc != 0 and 'AlreadyExists' not in _action_create_resource.stderr
+
+- debug: msg="tenant {{ _tenant_id }} created, waiting for it to be ready"
+
+- name: check if tenant {{ _tenant_id }} is reconciled
+  shell: oc get tenant {{ _tenant_id }} -n {{ namespace }} -o jsonpath='{.status.tenantId}'
+  register: _action_get_resource
+  until: _action_get_resource.rc == 0 and _action_get_resource.stdout != ''
+
+# details about the tenant are exported to a secret
+# get this secret and log the information in it
+
+- debug: msg="retrieving details for tenant {{ _tenant_id }}"
+
+- name: get tenant {{ _tenant_id }} host url from details secret {{ _tenant_detail_secret_name }}
+  shell: oc get secret {{ _tenant_detail_secret_name }} -n {{ namespace }} -o jsonpath='{.data.adminURL}'
+  register: _action_get_tenant_host
+
+- set_fact:
+    _tenant_host: "{{ _action_get_tenant_host.stdout | b64decode }}"
+
+- debug: msg="tenant {{ _tenant_id }} host is {{ _tenant_host }} with user {{ _tenant_admin_username }}"

--- a/ansible/roles/threescale/tasks/delete-tenant.yml
+++ b/ansible/roles/threescale/tasks/delete-tenant.yml
@@ -1,0 +1,63 @@
+---
+
+# set internal util variables
+
+- set_fact:
+    _tenant_id: "{{ tenant_id_format | format(item|int) }}"
+    _tenant_count: "{{ item }}"
+
+- debug: msg="deleting tenant {{ _tenant_id }} custom resource"
+
+- name: get tenant id in 3scale database
+  shell: oc get tenant {{ _tenant_id }} -n {{ namespace }} -o jsonpath='{.status.tenantId}'
+  register: _action_get_tenant_api_id
+  failed_when: false
+
+- block:
+  - set_fact:
+      _api_tenant_id: "{{ _action_get_tenant_api_id.stdout }}"
+
+  - debug: msg="deleting tenant {{ _tenant_id }} from 3scale database"
+
+  - name: delete tenant {{ _tenant_id }} with 3scale api
+    uri:
+      url: "{{ threescale_master_host }}/master/api/providers/{{ _api_tenant_id }}.xml"
+      method: DELETE
+      body: "access_token={{ threescale_master_token }}&id={{ _api_tenant_id }}"
+      validate_certs: false
+      status_code: [200, 404]
+    register: _action_api_delete_tenant
+    until: _action_api_delete_tenant.status in [200, 404]
+    retries: 3
+    delay: 5
+
+  - name: delete account {{ _tenant_id }} with 3scale api
+    uri:
+      url: "{{ threescale_master_host }}/admin/api/accounts/{{ _api_tenant_id }}.xml"
+      method: DELETE
+      body: "access_token={{ threescale_master_token }}&id={{ _api_tenant_id }}"
+      validate_certs: false
+      status_code: [200, 404]
+    register: _action_api_delete_account
+    until: _action_api_delete_account.status in [200, 404]
+    retries: 3
+    delay: 5
+
+  - name: delete tenant {{ _tenant_id }} custom resource
+    shell: oc delete tenant {{ _tenant_id }} -n {{ namespace }}
+    register: _action_delete_tenant_resource
+    failed_when: _action_delete_tenant_resource.rc != 0 and 'NotFound' not in _action_delete_tenant_resource.stderr
+  when: _action_get_tenant_api_id.rc == 0
+
+# admin credential secrets are not cleaned up by the 3scale operator
+# delete the generated admin credential secrets
+
+- debug: msg="deleting credentials secret for tenant {{ _tenant_id }}"
+
+- set_fact:
+    _tenant_admin_secret_name: "{{ _tenant_id }}-admin-credentials"
+
+- name: delete secret {{ _tenant_admin_secret_name }}
+  shell: oc delete secret {{ _tenant_admin_secret_name }} -n {{ namespace }}
+  register: _action_delete_credentials_secret
+  failed_when: _action_delete_credentials_secret.rc != 0 and 'NotFound' not in _action_delete_credentials_secret.stderr

--- a/ansible/roles/threescale/tasks/main.yml
+++ b/ansible/roles/threescale/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+
+- name: get master host url from route
+  shell: oc get route -n {{ namespace }} --selector=zync.3scale.net/route-to=system-master -o jsonpath='{.items[0].spec.host}'
+  register: _action_get_threescale_master_host
+
+- name: get master access token from secret
+  shell: oc get secret {{ seed_secret_name }} -n {{ namespace }} -o jsonpath='{.data.MASTER_ACCESS_TOKEN}'
+  register: _action_get_threescale_access_token
+
+- set_fact:
+    threescale_master_host: https://{{ _action_get_threescale_master_host.stdout }}
+    threescale_master_token: "{{ _action_get_threescale_access_token.stdout | b64decode }}"
+
+- debug: msg="found 3scale master host - {{ threescale_master_host }}"
+
+- name: create 3scale tenants
+  include_tasks: create-tenant.yml
+  with_sequence: count="{{ lab_user_count }}"
+  when: action == "install"
+
+- name: delete 3scale tenants
+  include_tasks: delete-tenant.yml
+  with_sequence: count="{{ lab_user_count }}"
+  when: action == "uninstall"

--- a/ansible/roles/threescale/templates/tenant-secret.json.j2
+++ b/ansible/roles/threescale/templates/tenant-secret.json.j2
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ tenant_admin_secret }}
+data:
+  admin_password: {{ tenant_admin_password }}
+type: Opaque

--- a/ansible/roles/threescale/templates/tenant.json.j2
+++ b/ansible/roles/threescale/templates/tenant.json.j2
@@ -1,0 +1,16 @@
+apiVersion: capabilities.3scale.net/v1alpha1
+kind: Tenant
+metadata:
+  name: {{ tenant_name }}
+spec:
+  email: {{ tenant_admin_email }}
+  username: {{ tenant_admin_user }}
+  passwordCredentialsRef:
+    name: {{ tenant_admin_secret }}
+  masterCredentialsRef:
+    name: {{ seed_secret_name }}
+  organizationName: {{ tenant_name }}
+  systemMasterUrl: {{ threescale_master_host }}
+  tenantSecretRef:
+    name: {{ tenant_detail_secret_name }}
+    namespace: {{ tenant_detail_secret_namespace }}

--- a/walkthroughs/summit-2020-lab/walkthrough.adoc
+++ b/walkthroughs/summit-2020-lab/walkthrough.adoc
@@ -32,6 +32,7 @@
 :3scale-app-name: {3scale-base-name}-app
 :3scale-api-key: {3scale-base-name}-key
 :3scale-staging-api-host: https://{user-username}-traffic-api-staging.{openshift-app-host}:443
+:3scale-management-url: https://{user-username}-tenant-admin.{openshift-app-host}
 
 :is-name: traffic-frontend
 
@@ -99,7 +100,7 @@ image::images/arch.png[integration, role="integr8ly-img-responsive"]
 [type=walkthroughResource,serviceName=3scale]
 .3Scale
 ****
-* link:{api-management-url}[Console, window="_blank"]
+* link:{3scale-management-url}[Console, window="_blank"]
 * link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.7/[Documentation, window="_blank"]
 * link:https://www.redhat.com/en/technologies/jboss-middleware/3scale[Overview, window="_blank"]
 ****
@@ -549,7 +550,7 @@ Here's a quick overview of these terms:
 
 === API Management Login
 
-. Open the link:{api-management-url}[3scale Login screen, window="_blank"] and click the *Red Hat Single Sign On* option. This triggers an OAuth Flow and redirects you back to the {3Scale-ProductName} Dashboard, or will request you to login using the same flow as you've become accustomed to.
+. Open the link:{3scale-management-url}[3scale Login screen, window="_blank"] and click the *Red Hat Single Sign On* option. This triggers an OAuth Flow and redirects you back to the {3Scale-ProductName} Dashboard, or will request you to login using the same flow as you've become accustomed to.
 . Upon successful login enter your account details as:
 .. *Username*: `{user-username}`
 .. *Email*: `{user-username}@example.com`


### PR DESCRIPTION
add a role for threescale to support:
- creating a threescale tenant per user
- deleting a threescale tenant per user

verification:
- run the install playbook against an rhmi 2.x cluster
- ensure a tenant is created for each user
- ensure the admin login for the tenant is the same as for rhmi
- run the uninstall playbook against the cluster
- ensure tenants are removed from 3scale