### PR TITLE
use template when creating fuse cr

### DIFF
--- a/rhmi/templates/fuse.yaml
+++ b/rhmi/templates/fuse.yaml
@@ -1,0 +1,48 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+name: fuse
+objects:
+- apiVersion: syndesis.io/v1beta1
+  kind: Syndesis
+  metadata:
+    name: ${FUSE_CR_NAME}
+    namespace: ${USER_FUSE_NAMESPACE}
+  spec:
+    addons:
+      camelk: {}
+      dv:
+        resources: {}
+      jaeger:
+        clientOnly: true
+        operatorOnly: true
+      knative: {}
+      ops: {}
+      publicApi: {}
+      todo: {}
+    backup: {}
+    components:
+      grafana:
+        resources: {}
+      meta:
+        resources: {}
+      oauth: {}
+      prometheus:
+        resources: {}
+      server:
+        features:
+          managementUrlFor3scale: '${THREESCALE_MANAGEMENT_URL}'
+        resources: {}
+      upgrade:
+        resources: {}
+    forceMigration: false
+parameters:
+- description: Name of the fuse custom resource
+  name: FUSE_CR_NAME
+  required: true
+- description: The user fuse namespace
+  name: USER_FUSE_NAMESPACE
+  required: true
+- description: 3scale management url
+  name: THREESCALE_MANAGEMENT_URL
+  required: true


### PR DESCRIPTION
Use a template when creating the fuse CR instead of copying it from the Fuse namespace.